### PR TITLE
Fix borderradius for ios

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ class UserAvatar extends Component {
 
     if (!name) throw new Error('Avatar requires a name');
 
+    if(typeof size !== 'number') size = parseInt(size);
+
     const abbr = initials(name);
 
     const borderRadius = size * 0.5;

--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ function sumChars(str) {
 class UserAvatar extends Component {
   render() {
     let {
-      borderRadius = 50,
       src,
       name,
       color,
@@ -39,6 +38,8 @@ class UserAvatar extends Component {
     if (!name) throw new Error('Avatar requires a name');
 
     const abbr = initials(name);
+
+    const borderRadius = size * 0.5;
 
     const imageStyle = {
       borderRadius


### PR DESCRIPTION
This PR fixes #1 , where the border-radius is wrong for iOS. 

Also, on iOS it is important to work with the right types, and this PR will fix this also.

Currently, <UserAvatar size="60" ...>  ends up with an exception, that a string can not be type-casted to NSNumber.

![screen shot 2017-01-19 at 17 25 36](https://cloud.githubusercontent.com/assets/1758597/22115709/5ceccbc4-de6e-11e6-8a5c-b8419727eb74.png)
