### PR TITLE
Add default-value for name if 'initials' fails to prevent empty avatars

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,13 +33,15 @@ class UserAvatar extends Component {
       colors = defaultColors,
       size,
       style,
+      defaultName,
     } = this.props;
 
     if (!name) throw new Error('Avatar requires a name');
 
     if(typeof size !== 'number') size = parseInt(size);
 
-    const abbr = initials(name);
+    let abbr = initials(name);
+    if(!abbr) abbr = defaultName;
 
     const borderRadius = size * 0.5;
 


### PR DESCRIPTION
Currently an empty circle is drawn if a username is passed with only non-characters like question marks or something else.

Thats way it will be never possible to fall back e.g. to show a question mark if a avatar is invalid.
To achieve this i've added a "defaultName" property that will be shown, if the function "initials()" will return an empty string (what happened in the scenario described above)

This PR will not break compatibility to previous versions, but makes the following screenshot possible (green avatar): 


![screen shot 2017-01-21 at 11 19 17](https://cloud.githubusercontent.com/assets/1758597/22173718/9dcfe5b4-dfcb-11e6-9872-1af8174427a8.png)
