### PR TITLE
Allow to pass a third-party-Image-component instead of the builtin Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Based on the great library for React: https://github.com/wbinnssmith/react-user-
   <UserAvatar size="50" name="Jane Doe" color="#000" />
 ```
 
+## User-defined Image-Component
+
+It is also possible to use another Image-Component than the built-in `<Image>`.
+
+```js
+  <UserAvatar size="50" name="John Doe" component={CachedImage} />
+```
+
 The fallback avatar's color may be set by passing in the `color` prop, or you can customize the range of colors
 used by passing in an array of `colors`. The component uses a simple calculation to consistently use the same
 color for the same user's name every time.

--- a/index.js
+++ b/index.js
@@ -64,7 +64,14 @@ class UserAvatar extends Component {
 
     let inner, classes;
     if (src) {
-      inner = <Image style={imageStyle} source={{ uri: src }} />
+      
+      const props = {
+        style: imageStyle,
+        source: {uri: src}
+      }
+      
+      inner = React.createElement( this.props.component || Image, props )
+
     } else {
       let background;
       if (color) {


### PR DESCRIPTION
With this PR we are able to use another `<Image>`-component instead the builtin one.

Like so:

`<UserAvatar size="50" name="John Doe" component={CachedImage} />`

It will not break any compatibility as it falls back to the standard Image-component.