### PR TITLE
fix: textStyle props is added, feat: create-cache-key-function upgraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "^3.7.5"
   },
   "resolutions": {
-    "react-native/@jest/create-cache-key-function": "^27.0.1"
+    "react-native/@jest/create-cache-key-function": "^27.0.2"
   },
   "jest": {
     "preset": "react-native",

--- a/src/__tests__/UserAvatar.test.js
+++ b/src/__tests__/UserAvatar.test.js
@@ -1,5 +1,5 @@
 /* eslint max-len: 0 */
-
+jest.setTimeout(30000);
 import 'react-native';
 import {Image} from 'react-native';
 import React from 'react';

--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -9,6 +9,7 @@ import {
 } from '../helpers';
 
 beforeEach(function() {
+  jest.setTimeout(10000);
   global.fetch = jest.fn().mockImplementation(() => {
     mockResponseObject = {
       '_bodyBlob': {

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,8 @@ const UserAvatar = (props) => {
       });
       return () => controller.abort();
     } else {
-      setInner(<TextAvatar textColor={textColor} size={size} name={name} />);
+      // eslint-disable-next-line max-len
+      setInner(<TextAvatar textColor={textColor} size={size} name={name} textStyle={textStyle} />);
     }
   }, [textColor, size, name, component, imageStyle, src]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,7 +1302,14 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^26.5.0", "@jest/create-cache-key-function@^27.0.1", "@jest/create-cache-key-function@^27.5.0":
+"@jest/create-cache-key-function@^26.5.0", "@jest/create-cache-key-function@^27.0.2":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz#7448fae15602ea95c828f5eceed35c202a820b31"
+  integrity sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==
+  dependencies:
+    "@jest/types" "^27.5.1"
+
+"@jest/create-cache-key-function@^27.5.0":
   version "27.5.0"
   resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.5.0.tgz#0f713af7f9d533f3f6c31130c87cd668d1e5fd06"
   integrity sha512-ibNE/ngRfVJj4y5cf9QnBbVKovO44Hfw13mEVSJcO1+MYh31g1gh9mvWNmOmWZjiPTwaIBSoYfLvebGypzUbVw==
@@ -1447,6 +1454,17 @@
   version "27.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.0.tgz#6ad04a5c5355fd9f46e5cf761850e0edb3c209dd"
   integrity sha512-oDHEp7gwSgA82RZ6pzUL3ugM2njP/lVB1MsxRZNOBk+CoNvh9SpH1lQixPFc/kDlV50v59csiW4HLixWmhmgPQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"


### PR DESCRIPTION
- The textStyle prop is added to the TextAvatar component in the index.js file.
- In package.json, upgraded react-native/@jest/create-cache-key-function from ^27.0.1 to ^27.0.2